### PR TITLE
Ensure writable directories for SQLite database and logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,6 @@ Pokud `CHAT_API_URL` není nastavená, aplikace použije jednoduchého demonstra
 
 ## Poznámky
 
-- Databáze SQLite se ukládá do adresáře `data/`
-- Logy se nacházejí v `logs/app.log`
+- Databáze SQLite se ukládá do adresáře `data/` (pokud není zapisovatelný, automaticky se použije `/tmp/vse-web/data`)
+- Logy se nacházejí v `logs/app.log` (nebo v `/tmp/vse-web/logs/app.log`)
 - V produkčním prostředí nezapomeňte nastavit silný `JWT_SECRET` a používat HTTPS

--- a/db.js
+++ b/db.js
@@ -3,7 +3,9 @@ import path from 'path';
 import sqlite3 from 'sqlite3';
 import { open } from 'sqlite';
 
+import { ensureWritableDir } from './pathUtils.js';
 
+const dataDir = ensureWritableDir({ envVar: 'DATA_DIR', defaultSubdir: 'data' });
 
 const dbPromise = open({
   filename: path.join(dataDir, 'app.db'),

--- a/logger.js
+++ b/logger.js
@@ -1,4 +1,9 @@
+import path from 'path';
+import winston from 'winston';
 
+import { ensureWritableDir } from './pathUtils.js';
+
+const logDir = ensureWritableDir({ envVar: 'LOG_DIR', defaultSubdir: 'logs' });
 
 export const logger = winston.createLogger({
   level: 'info',


### PR DESCRIPTION
## Summary
- ensure the SQLite database uses a writable directory via `ensureWritableDir`
- update the logger configuration to create log files in a writable location
- document the `/tmp` fallbacks for database and log storage

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_b_68e5844a35408321bc9f5d854ba5e855